### PR TITLE
FIX KEY UP and KEY DOWN

### DIFF
--- a/app/src/main/java/com/cy8018/iptv/player/PlaybackActivity.java
+++ b/app/src/main/java/com/cy8018/iptv/player/PlaybackActivity.java
@@ -117,12 +117,12 @@ public class PlaybackActivity extends FragmentActivity {
 
         if (event.getAction() == KeyEvent.ACTION_DOWN
                 &&  (event.getKeyCode() == KeyEvent.KEYCODE_DPAD_UP || event.getKeyCode() == KeyEvent.KEYCODE_CHANNEL_UP)) {
-            mFragment.SwitchChannel(true);
+            mFragment.SwitchChannel(false);
             return true;
         }
         if (event.getAction() == KeyEvent.ACTION_DOWN
                 && (event.getKeyCode() == KeyEvent.KEYCODE_DPAD_DOWN || event.getKeyCode() == KeyEvent.KEYCODE_CHANNEL_DOWN)) {
-            mFragment.SwitchChannel(false);
+            mFragment.SwitchChannel(true);
             return true;
         }
         if (event.getAction() == KeyEvent.ACTION_DOWN && event.getKeyCode() == KeyEvent.KEYCODE_DPAD_LEFT) {


### PR DESCRIPTION
I think is more logical when KeyDown is pressed to increase channel and KeyUP decrease channel as channels are sorted ASC 